### PR TITLE
✨ Refactor JSON schema validation for password fields

### DIFF
--- a/src/forms/ForgotPasswordForm.tsx
+++ b/src/forms/ForgotPasswordForm.tsx
@@ -37,7 +37,6 @@ export default function ForgotPasswordForm({ onSubmit }: Prop) {
   } = useForm<ForgotPasswordFields>({
     resolver: ajvResolver(schema, {
       formats: fullFormats,
-      removeAdditional: true,
     }),
     reValidateMode: "onChange",
   });

--- a/src/forms/LogInForm.tsx
+++ b/src/forms/LogInForm.tsx
@@ -44,7 +44,6 @@ export default function LogInForm({ onSubmit }: Prop) {
   } = useForm<LoginFormFields>({
     resolver: ajvResolver(schema, {
       formats: fullFormats,
-      removeAdditional: true,
     }),
     reValidateMode: "onChange",
   });

--- a/src/forms/RegisterForm.tsx
+++ b/src/forms/RegisterForm.tsx
@@ -21,7 +21,11 @@ const schema = {
   properties: {
     email: { type: "string", format: "email" },
     password: { type: "string", pattern: PASSWORD_REGEX },
-    confirmPassword: { const: { $data: "1/password" } },
+    confirmPassword: {
+      type: "string",
+      minLength: 1,
+      const: { $data: "1/password" },
+    },
     firstName: { type: "string", minLength: 2 },
     lastName: { type: "string", minLength: 2 },
   },

--- a/src/forms/RegisterForm.tsx
+++ b/src/forms/RegisterForm.tsx
@@ -16,12 +16,12 @@ export type RegisterFormFields = {
   lastName: string;
 };
 
-const schema: JSONSchemaType<RegisterFormFields> = {
+const schema = {
   type: "object",
   properties: {
     email: { type: "string", format: "email" },
     password: { type: "string", pattern: PASSWORD_REGEX },
-    confirmPassword: { type: "string", pattern: PASSWORD_REGEX },
+    confirmPassword: { const: { $data: "1/password" } },
     firstName: { type: "string", minLength: 2 },
     lastName: { type: "string", minLength: 2 },
   },
@@ -37,7 +37,7 @@ const schema: JSONSchemaType<RegisterFormFields> = {
       confirmPassword: "Passwords do not match.",
     },
   },
-};
+} as unknown as JSONSchemaType<RegisterFormFields>;
 
 export type Prop = {
   onSubmit: (data: RegisterFormFields) => Promise<void>;
@@ -50,7 +50,7 @@ export default function RegisterForm({ onSubmit }: Prop) {
     formState: { errors, isSubmitting },
     setError,
   } = useForm<RegisterFormFields>({
-    resolver: ajvResolver(schema, { formats: fullFormats }),
+    resolver: ajvResolver(schema, { formats: fullFormats, $data: true }),
     reValidateMode: "onChange",
   });
 

--- a/src/forms/ResetPasswordForm.tsx
+++ b/src/forms/ResetPasswordForm.tsx
@@ -14,23 +14,23 @@ export type ResetPasswordFields = {
   token?: string;
 };
 
-const schema: JSONSchemaType<ResetPasswordFields> = {
+const schema = {
   type: "object",
   properties: {
     newPassword: { type: "string", pattern: PASSWORD_REGEX },
-    confirmPassword: { type: "string", pattern: PASSWORD_REGEX },
+    confirmPassword: { const: { $data: "1/newPassword" } },
     token: { type: "string", nullable: true },
   },
   required: ["newPassword", "confirmPassword"],
   additionalProperties: false,
   errorMessage: {
     properties: {
-      password:
+      newPassword:
         "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character.",
       confirmPassword: "Passwords do not match.",
     },
   },
-};
+} as unknown as JSONSchemaType<ResetPasswordFields>;
 
 export type Prop = {
   onSubmit: (data: ResetPasswordFields) => Promise<{ message: string }>;
@@ -46,7 +46,7 @@ export default function ResetPasswordForm({ onSubmit }: Prop) {
   } = useForm<ResetPasswordFields>({
     resolver: ajvResolver(schema, {
       formats: fullFormats,
-      removeAdditional: true,
+      $data: true,
     }),
     reValidateMode: "onChange",
   });


### PR DESCRIPTION
Ensure that the confirmPassword field matches the value of newPassword to improve user experience and data integrity. Update schema validation for ResetPasswordFields and RegisterFormFields to include this check. Use $data keyword for referring to another field's value.

- Modified schema validation for ResetPasswordFields and RegisterFormFields
- Added check for confirmPassword field to match newPassword
- Utilized $data keyword for referencing another field's value in schema validation